### PR TITLE
Adding test support for `graphql`@14

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -1,4 +1,4 @@
 
 graphql:
-  versions: ^0.12.0  || ^0.13.0
+  versions: ^0.12.0  || ^0.13.0 || ^14.0.0
   commands: mocha test/index.js

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ All of the rules provided by this plugin have a few options in common. There are
 You also have to specify a schema. You can either do it using _one_ of these options:
 
 - `schemaJson`: Your schema as JSON.
-- `schemaJsonFilepath`: The absolute path to your schema as a .json file.
+- `schemaJsonFilepath`: The absolute path to your schema as a .json file. (Warning: this variant is incompatible with `eslint --cache`.)
 - `schemaString`: Your schema in the Schema Language format as a string.
 
 Alternatively, you can use a [.graphqlconfig](https://github.com/graphcool/graphql-config) file instead of the above three options. If you do there's one more option to know about:
@@ -102,7 +102,7 @@ module.exports = {
       // Import your schema JSON here
       schemaJson: require('./schema.json'),
 
-      // OR provide absolute path to your schema JSON
+      // OR provide absolute path to your schema JSON (but not if using `eslint --cache`!)
       // schemaJsonFilepath: path.resolve(__dirname, './schema.json'),
 
       // OR provide the schema in the Schema Language format
@@ -132,7 +132,7 @@ module.exports = {
       // Import your schema JSON here
       schemaJson: require('./schema.json'),
 
-      // OR provide absolute path to your schema JSON
+      // OR provide absolute path to your schema JSON (but not if using `eslint --cache`!)
       // schemaJsonFilepath: path.resolve(__dirname, './schema.json'),
 
       // OR provide the schema in the Schema Language format
@@ -162,7 +162,7 @@ module.exports = {
       // Import your schema JSON here
       schemaJson: require('./schema.json'),
 
-      // OR provide absolute path to your schema JSON
+      // OR provide absolute path to your schema JSON (but not if using `eslint --cache`!)
       // schemaJsonFilepath: path.resolve(__dirname, './schema.json'),
 
       // OR provide the schema in the Schema Language format
@@ -193,7 +193,7 @@ module.exports = {
       // Import your schema JSON here
       schemaJson: require('./schema.json'),
 
-      // OR provide absolute path to your schema JSON
+      // OR provide absolute path to your schema JSON (but not if using `eslint --cache`!)
       // schemaJsonFilepath: path.resolve(__dirname, './schema.json'),
 
       // OR provide the schema in the Schema Language format

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,9 @@ const envGraphQLValidatorNames = {
     'KnownFragmentNames',
     'NoUndefinedVariables',
     'NoUnusedFragments',
+    // `graphql` < 14
+    'ProvidedNonNullArguments',
+    // `graphql`@14
     'ProvidedRequiredArguments',
     'ScalarLeafs',
   ),

--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -105,7 +105,6 @@ describe('processors', () => {
           nodeType: 'TaggedTemplateExpression',
           ruleId: 'graphql/required-fields',
           severity: 2,
-          source: 'ESLintPluginGraphQLFile`query { stories { comments { text } } }'
         });
       });
 
@@ -119,7 +118,6 @@ describe('processors', () => {
           nodeType: 'TaggedTemplateExpression',
           ruleId: 'graphql/required-fields',
           severity: 2,
-          source: '  greetings {'
         });
       });
     });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on eslint-plugin-graphql!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Helps address apollographql/eslint-plugin-graphql#180 by adding:

- support for testing against `graphql`@14
- making sure we can have backwards-compatible behavior / tests

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull request by labeling this pull request when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
